### PR TITLE
Force https for www.resourcedata.org

### DIFF
--- a/etc/nginx.conf
+++ b/etc/nginx.conf
@@ -33,6 +33,7 @@ http {
     proxy_cache_path /var/cache/nginx/proxycache levels=1:2 keys_zone=cache:30m max_size=250m;
     proxy_temp_path /var/cache/nginx/proxytemp 1 2;
 
+    # Redirect resourcedata.org to www.resourcedata.org
     server {
         listen 80;
         server_name resourcedata.org;
@@ -43,19 +44,27 @@ http {
         listen 80 default_server;
         server_name _;
 
-        if ($http_x_forwarded_proto != "https") {
-            return 301 https://$host$request_uri;
-        }
-
         add_header Access-Control-Allow-Origin *;
 
         client_max_body_size 100M;
 
-        location / {
+        # Special, somewhat redundant location to always proxy
+        # the health check to the upstream server, without checking
+        # if the request came in over HTTP or HTTPS.
+        location /health_check {
+            proxy_set_header Host $http_host;
+            proxy_redirect off;
+            proxy_next_upstream error;
+            proxy_pass http://127.0.0.1:8080/;
+            break;
+        }
 
-            # once we have an ssl cert, uncomment these
-            # ssl_certificate /etc/nginx/ssl/server.crt;
-            # ssl_certificate_key /etc/nginx/ssl/server.key;
+        location / {
+            #  Any request that did not originally come in to the ELB
+            # over HTTPS gets redirected.
+            if ($http_x_forwarded_proto != "https") {
+                return 301 https://$host$request_uri;
+            }
 
             proxy_pass http://127.0.0.1:8080/;
             # Keep headers set by AWS ELB.

--- a/etc/nginx.conf
+++ b/etc/nginx.conf
@@ -34,7 +34,7 @@ http {
     proxy_temp_path /var/cache/nginx/proxytemp 1 2;
 
     server {
-        listen 80 default_server
+        listen 80 default_server;
         server_name resourcedata.org;
         return 301 $http_x_forwarded_proto://www.resourcedata.org$request_uri;
     }

--- a/etc/nginx.conf
+++ b/etc/nginx.conf
@@ -37,7 +37,7 @@ http {
     server {
         listen 80;
         server_name resourcedata.org;
-        return 301 $http_x_forwarded_proto://www.resourcedata.org$request_uri;
+        return 301 https://www.resourcedata.org$request_uri;
     }
 
     server {

--- a/etc/nginx.conf
+++ b/etc/nginx.conf
@@ -34,8 +34,18 @@ http {
     proxy_temp_path /var/cache/nginx/proxytemp 1 2;
 
     server {
+        listen 80 default_server
+        server_name resourcedata.org;
+        return 301 $http_x_forwarded_proto://www.resourcedata.org$request_uri;
+    }
+
+    server {
         listen 80 default_server;
         server_name _;
+
+        if ($http_x_forwarded_proto != "https") {
+            return 301 https://$server_name$request_uri;
+        }
 
         add_header Access-Control-Allow-Origin *;
 
@@ -48,9 +58,10 @@ http {
             # ssl_certificate_key /etc/nginx/ssl/server.key;
 
             proxy_pass http://127.0.0.1:8080/;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
+            # Keep headers set by AWS ELB.
+            # proxy_set_header X-Real-IP $remote_addr;
+            # proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            # proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Forwarded-Server $host;
             proxy_set_header X-Forwarded-Host $host;
             proxy_set_header Host $host;

--- a/etc/nginx.conf
+++ b/etc/nginx.conf
@@ -34,7 +34,7 @@ http {
     proxy_temp_path /var/cache/nginx/proxytemp 1 2;
 
     server {
-        listen 80 default_server;
+        listen 80;
         server_name resourcedata.org;
         return 301 $http_x_forwarded_proto://www.resourcedata.org$request_uri;
     }
@@ -44,7 +44,7 @@ http {
         server_name _;
 
         if ($http_x_forwarded_proto != "https") {
-            return 301 https://$server_name$request_uri;
+            return 301 https://$host$request_uri;
         }
 
         add_header Access-Control-Allow-Origin *;


### PR DESCRIPTION
Updated the nginx config to redirect all http users to https. It also redirects resourcedata.org to the canonical www.resourcedata.org.