### PR TITLE
104 add version file to docker container

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -12,6 +12,9 @@ env:
 
 build:
   ci:
+    # Create the version file
+    - ./create_version.sh
+
     # Pull latest image to be used as cache
     - docker pull nrgi/resourcedata.org:$BRANCH || echo 'Cache not available'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,6 +99,7 @@ ADD ./etc/my_init.d/65_extensions /etc/my_init.d
 ADD ./etc/my_init.d/70_initdb /etc/my_init.d
 ADD ./etc/my_init.d/80_initadmin /etc/my_init.d
 ADD ./etc/svc /etc/service
+COPY version.txt $CKAN_HOME/
 CMD ["/sbin/my_init"]
 
 # Volumes

--- a/create_version.sh
+++ b/create_version.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+cat > version.txt << EOF
+{
+  "commit_sha": "$COMMIT",
+  "image": "nrgi/resourcedata.org:$BRANCH.$COMMIT"
+}
+EOF

--- a/etc/nginx.conf
+++ b/etc/nginx.conf
@@ -59,6 +59,11 @@ http {
             break;
         }
 
+        location /version.txt {
+            root /usr/lib/ckan/default/version.txt;
+
+        }
+
         location / {
             #  Any request that did not originally come in to the ELB
             # over HTTPS gets redirected.

--- a/etc/nginx.conf
+++ b/etc/nginx.conf
@@ -60,7 +60,7 @@ http {
         }
 
         location /version.txt {
-            root /usr/lib/ckan/default/version.txt;
+            root /usr/lib/ckan/default;
 
         }
 


### PR DESCRIPTION
Added a version.txt page that contains the Docker image name from which the site currently runs so that we can quickly say which version of the site is deployed.

This is related to https://github.com/NRGI/resourcedata.org/issues/104 .